### PR TITLE
Handle missing template directory in apply command

### DIFF
--- a/src/scraper/cli.py
+++ b/src/scraper/cli.py
@@ -263,6 +263,11 @@ def _run_apply_safe(args: argparse.Namespace = None):
         export_formats = [ExportFormat(fmt) for fmt in (args.export if hasattr(args, 'export') else ['json'])]
     else:
         # Interactive mode
+        if not Config.TEMPLATES_DIR.exists():
+            print("\n❌ Templates directory not found.")
+            print(f"   Directory: {Config.TEMPLATES_DIR}")
+            return
+
         templates = list(Config.TEMPLATES_DIR.glob("*.json"))
         
         if not templates:


### PR DESCRIPTION
## Summary
- add explicit check for missing templates directory before listing templates

## Testing
- `flake8 . --exclude interactive-web-scraper/venv | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684387aedc8883299cf8d9aa87f67cef