### PR TITLE
Fix missing imports for Selenium exceptions

### DIFF
--- a/src/scraper/core/template_scraper.py
+++ b/src/scraper/core/template_scraper.py
@@ -15,6 +15,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    ElementNotInteractableException,
+)
 
 # Engine-specific imports
 from .base_scraper import BaseScraper


### PR DESCRIPTION
## Summary
- import `NoSuchElementException`, `StaleElementReferenceException` and `ElementNotInteractableException` in `TemplateScraper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684391de76648329b9ce5b7383cfc539